### PR TITLE
Bump alpine version to 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.14
+FROM alpine:3.16
 RUN apk --no-cache add postgresql-client
 ENTRYPOINT [ "psql" ]


### PR DESCRIPTION
Bump alpine version to 3.16. It should provide a 14.9 version for psql