### PR TITLE
Bump alpine version to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.16
+FROM alpine:3.18
 RUN apk --no-cache add postgresql-client
 ENTRYPOINT [ "psql" ]


### PR DESCRIPTION
Bump alpine version to 3.18. It should provide a 15.4 version for psql